### PR TITLE
Complete rework and update of JPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 [![ownCloud](../../raw/master/images/ownCloud.png)](../../../owncloud)
 ## ownCloud
 
-The JPS package deploys ownCloud that initially contains 1 application server and 1 database container. The package provides vertical scalling per node and horizontal scaling for each layer out-of-the-box.
+The JPS package deploys ownCloud that initially contains 1 application server and 1 database container. 
+
+You also have the choice of using a dedicated storage node or a clustered storage node.
 
 ### Highlights
 This package is designed to deploy ownCloud environment which represents an open source and free file cloud storage. It can be easily used for data sharing and synchronization, as well as just for storing documents.
@@ -14,16 +16,16 @@ This package is designed to deploy ownCloud environment which represents an open
 
 Layer                |     Server    | Number of CTs <br/> by default | Cloudlets per CT <br/> (reserved/dynamic) | Options
 -------------------- | --------------| :----------------------------: | :---------------------------------------: | :-----:
-AS                   | Apache 2 (MOD_PHP) |       1                        |           1 / 16                          | -
-DB                   |    MySQL      |       1                        |           1 / 16                           | -
+AS                   | Apache 2 <br/> Litespeed |       1                        |           1 / 16                          | -
+DB                   |    MariaDB      |       1                        |           1 / 8                           | -
 
 * AS - Application server 
 * DB - Database 
 * CT - Container
 
-**ownCloud Version**: 8.1.1<br/>
-**PHP Engine**: PHP 5.5.36<br/>
-**MySQL Database**: 5.7.12
+**ownCloud Version**: 10.7<br/>
+**PHP Engine**: PHP 7.4.15<br/>
+**MariaDB Database**: 10.x
 
 ### Deployment
 

--- a/manifest.jps
+++ b/manifest.jps
@@ -1,6 +1,5 @@
 type: install
 id: owncloud
-version: 1.7
 name: ownCloud
 baseUrl: https://raw.githubusercontent.com/panslothda/owncloud/master
 homepage: https://owncloud.org/
@@ -57,14 +56,11 @@ settings:
             disabled: true
             tooltip: "If this option is activated, the storage node will be made as a clustered version" 
 
-globals:
-  PASSWD: ${fn.password}
-
-
 onInstall:
   - deployApp
-  - set-sql-settings
-  - set-php-settings
+  - set-SQL-settings
+  - set-PHP-settings
+  - restart
 
 actions:
   deployApp:
@@ -73,37 +69,51 @@ actions:
       name: owncloud-${globals.version_owncloud}.zip
       context: ROOT
 
-  set-sql-settings:
-    prepareSqlDatabase:
-      - nodeType: mariadb10
-        loginCredentials:
-          user: root
-          password: "${nodes.sqldb.password}"
-        newDatabaseName: owncloud
-        newDatabaseUser:
-          name: owncloud
-          password: "${user.appPassword}"
-    cmd [mariadb10]: mysql -u root -p${nodes.sqldb.password} -e "grant all privileges on *.* to 'owncloud'@'%'"
+  set-SQL-settings:
+    - prepareSqlDatabase:
+        - nodeType: sqldb
+          loginCredentials:
+            user: root
+            password: "${nodes.sqldb.password}"
+          newDatabaseName: owncloud
+          newDatabaseUser:
+            name: owncloud
+            password: "${user.appPassword}"
 
-  set-php-settings:        
-    cmd [cp]: printf '<?php\n	$AUTOCONFIG = array(\n		"dbtype"	=> "mysql",\n		"dbname"	=> "owncloud",\n		"dbuser"	=> "owncloud",\n		"dbpass"	=> "${user.appPassword}",\n		"dbhost"	=> "${nodes.sqldb.address}",\n		"dbtableprefix" => "oc_",\n		"adminlogin"	=> "admin",\n		"adminpass"	=> "${user.appPassword}",\n		"directory"	=> "/var/www/webroot/ROOT/data",\n);' > /var/www/webroot/ROOT/config/autoconfig.php
-   
-    replaceInFile:
-      nodeGroup: cp
-      path: /etc/php.ini
-      replacements:
-        - replacement: post_max_size = 256M
-          pattern: post_max_size = 8M
-        - replacement: upload_max_filesize = 256M
-          pattern: upload_max_filesize = 2M
-        - replacement: max_execution_time = 300
-          pattern: max_execution_time = 30
-        - pattern: ";extension=gd.so"
-          replacement: extension=gd.so
-        - pattern: ";extension=intl.so"
-          replacement: extension=intl.so
-        - pattern: cgi.fix_pathinfo=0
-          replacement: cgi.fix_pathinfo=1
+  set-PHP-settings:        
+    - cmd [cp]: printf '<?php\n	$AUTOCONFIG = array(\n		"dbtype"	=> "mysql",\n		"dbname"	=> "owncloud",\n		"dbuser"	=> "owncloud",\n		"dbpass"	=> "${user.appPassword}",\n		"dbhost"	=> "${nodes.sqldb.address}",\n		"dbtableprefix" => "oc_",\n		"adminlogin"	=> "admin",\n		"adminpass"	=> "${user.appPassword}",\n		"directory"	=> "/var/www/webroot/ROOT/data",\n);' > /var/www/webroot/ROOT/config/autoconfig.php
+    - if ('${settings.litespeed}' == 'true'):
+        replaceInFile:
+          nodeType: cp
+          path: /usr/local/lsws/lsphp/etc/php.ini
+          replacements:
+            - pattern: post_max_size = 8M
+              replacement: post_max_size = 1024M
+            - pattern: upload_max_filesize = 2M
+              replacement: upload_max_filesize = 1024M
+            - pattern: max_execution_time = 30
+              replacement: max_execution_time = 600
+    - else:
+        replaceInFile:
+          nodeType: cp
+          path: /etc/php.ini
+          replacements:
+            - pattern: post_max_size = 100M
+              replacement: post_max_size = 1024M
+            - pattern: upload_max_filesize = 100M
+              replacement: upload_max_filesize = 1024M
+            - pattern: max_execution_time = 300
+              replacement: max_execution_time = 600
+            - pattern: ";extension=gd.so"
+              replacement: extension=gd.so
+            - pattern: ";extension=intl.so"
+              replacement: extension=intl.so
+            - pattern: cgi.fix_pathinfo=0
+              replacement: cgi.fix_pathinfo=1
+
+  restart:
+    - restartContainers:
+        nodeGroup: cp        
 
 success:
   email: /text/success-text.md

--- a/manifest.jps
+++ b/manifest.jps
@@ -57,12 +57,28 @@ settings:
             tooltip: "If this option is activated, the storage node will be made as a clustered version" 
 
 onInstall:
+  - mount
   - deployApp
   - set-SQL-settings
   - set-PHP-settings
+  - apply-settings
+  - optimise-owncloud
   - restart
 
 actions:
+  mount:
+    - if ('${settings.clustered-storage}' == 'true'):
+      - log: Mount Storage if clustered storage
+      - api:
+        - method: jelastic.environment.file.AddMountPointByGroup
+          params:
+            nodeGroup: cp
+            sourceNodeId: ${nodes.storage.master.id}
+            sourcePath: /data/ROOT
+            path: /var/www/webroot/ROOT
+            sourceAddressType: NODE_GROUP
+            protocol: NFS4  
+
   deployApp:
     deploy:  
       archive: https://download.owncloud.org/community/owncloud-${globals.version_owncloud}.zip
@@ -110,6 +126,28 @@ actions:
               replacement: extension=intl.so
             - pattern: cgi.fix_pathinfo=0
               replacement: cgi.fix_pathinfo=1
+            - pattern: ";extension=redis.so"  
+              replacement: extension=redis.so
+
+  apply-settings:
+    - restartContainers:
+        nodeGroup: cp
+    - sleep: 20000      
+    - cmd[cp]: curl -Lk ${env.domain}
+
+  optimise-owncloud:
+    - cmd[cp]: |-
+        REDIS="'\OC\Memcache\Redis'"
+        sed -i "36i     'filelocking.enabled' => true,"  /var/www/webroot/ROOT/config/config.php
+        sed -i "37i     'memcache.locking' => '\\\OC\\\Memcache\\\Redis',"  /var/www/webroot/ROOT/config/config.php
+        sed -i "38i     'memcache.local' => '\\\OC\\\Memcache\\\Redis',"  /var/www/webroot/ROOT/config/config.php
+        sed -i "39i     'redis' => ["  /var/www/webroot/ROOT/config/config.php
+        sed -i "40i     'host' => '/var/run/redis/redis.sock',"  /var/www/webroot/ROOT/config/config.php
+        sed -i "41i     'port' => 0,"  /var/www/webroot/ROOT/config/config.php
+        sed -i "42i     ],"  /var/www/webroot/ROOT/config/config.php
+        cd /var/www/webroot/ROOT
+        ./occ system:cron
+        crontab -l | { cat; echo "*  *  *  *  * /usr/bin/php -f /var/www/webroot/ROOT/occ system:cron"; } | crontab -
 
   restart:
     - restartContainers:

--- a/manifest.jps
+++ b/manifest.jps
@@ -2,7 +2,10 @@ type: install
 id: owncloud
 version: 1.7
 name: ownCloud
-baseUrl: https://raw.githubusercontent.com/jelastic-jps/owncloud/master/
+baseUrl: https://raw.githubusercontent.com/panslothda/owncloud/master
+homepage: https://owncloud.org/
+logo: images/ownCloud.png
+description: ownCloud represents an open source and free file cloud storage. It can be easily used for data sharing and synchronization, as well as just for storing documents.
 
 categories:
   - apps/file-management
@@ -12,36 +15,70 @@ categories:
 mixins:
   - configs/vers.yaml
 
+onBeforeInstall: /scripts/beforeinstall.js?_r=${fn.random}
+
+skipNodeEmails: true
+nodes: definedInOnBeforeInstall
+
+settings:
+  fields:
+    - name: litespeed
+      type: checkbox
+      caption: Install LiteSpeed High-Performance Web Server 
+      value: true
+      tooltip: "If this option is disabled, the service will be installed using NGINX application server"
+    - pack: ''
+      align: ''
+      defaultPadding: 1
+      defaultFlex: 0
+      caption: Compositefield
+      type: compositefield
+      name: compositefield
+      hideLabel: true
+      hidden: false
+    - name: ded-storage
+      type: checkbox
+      caption: Add a dedicated storage Node
+      value: true
+      tooltip: "If this option is disabled, the storage of the NGINX node will be used for all files"
+      showIf:
+        true:
+          - caption: Clustered storage for high availability and more storage
+            type: checkbox
+            name: clustered-storage
+            value: false
+            tooltip: "If this option is activated, the storage node will be made as a clustered version"
+
+        false:
+          - caption: Clustered storage for high availability and more storage
+            type: checkbox
+            name: clustered-storage
+            value: false
+            disabled: true
+            tooltip: "If this option is activated, the storage node will be made as a clustered version" 
+
 globals:
   PASSWD: ${fn.password}
-homepage: https://owncloud.org/
-logo: images/ownCloud.png
-description: ownCloud represents an open source and free file cloud storage. It can be easily used for data sharing and synchronization, as well as just for storing documents.
 
-nodes:
-  - cloudlets: 8
-    nodeType: apache2
-    engine: php7.4
-  - cloudlets: 8
-    nodeType: mysql5
+
 onInstall:
   - deploy:
       archive: https://download.owncloud.org/community/owncloud-${globals.version_owncloud}.zip
       name: owncloud-${globals.version_owncloud}.zip
       context: ROOT
   - prepareSqlDatabase:
-    - nodeType: mysql5
+    - nodeType: mariadb10
       loginCredentials:
         user: root
-        password: ${nodes.mysql5.password}
+        password: ${nodes.mariadb10.password}
       newDatabaseName: owncloud
       newDatabaseUser:
         name: owncloud
         password: ${globals.PASSWD}
-  - cmd [cp]: printf '<?php\n	$AUTOCONFIG = array(\n		"dbtype"	=> "mysql",\n		"dbname"	=> "owncloud",\n		"dbuser"	=> "owncloud",\n		"dbpass"	=> "${globals.PASSWD}",\n		"dbhost"	=> "${nodes.mysql5.address}",\n		"dbtableprefix" => "oc_",\n		"adminlogin"	=> "admin",\n		"adminpass"	=> "${user.appPassword}",\n		"directory"	=> "/var/www/webroot/ROOT/data",\n);' > /var/www/webroot/ROOT/config/autoconfig.php
+  - cmd [cp]: printf '<?php\n	$AUTOCONFIG = array(\n		"dbtype"	=> "mysql",\n		"dbname"	=> "owncloud",\n		"dbuser"	=> "owncloud",\n		"dbpass"	=> "${globals.PASSWD}",\n		"dbhost"	=> "${nodes.mariadb10.address}",\n		"dbtableprefix" => "oc_",\n		"adminlogin"	=> "admin",\n		"adminpass"	=> "${user.appPassword}",\n		"directory"	=> "/var/www/webroot/ROOT/data",\n);' > /var/www/webroot/ROOT/config/autoconfig.php
   - replaceInFile:
     - path: /etc/php.ini
-      nodeType: apache2
+      nodeGroup: cp
       replacements:
       - replacement: post_max_size = 256M
         pattern: post_max_size = 8M
@@ -55,15 +92,7 @@ onInstall:
         replacement: extension=intl.so
       - pattern: cgi.fix_pathinfo=0
         replacement: cgi.fix_pathinfo=1
-  - restartNode:
-      nodeType: apache2
 
-success: |
-  Below you will find your admin panel link, username and password.  
-  
-  
-  Admin panel URL: [${env.protocol}://${env.domain}/](${env.protocol}://${env.domain}/)  
-  Admin name: admin  
-  Password: ${user.appPassword}  
-  
-  To add custom domain name for your ownCloud installation follow the steps described in our [documentation](http://docs.jelastic.com/custom-domains)
+success:
+  email: /text/success-text.md
+  text: /text/success-text.md

--- a/manifest.jps
+++ b/manifest.jps
@@ -1,5 +1,6 @@
 type: install
 id: owncloud
+version: 1.7
 name: ownCloud
 baseUrl: https://raw.githubusercontent.com/jelastic-jps/owncloud/master
 homepage: https://owncloud.org/

--- a/manifest.jps
+++ b/manifest.jps
@@ -137,7 +137,6 @@ actions:
 
   optimise-owncloud:
     - cmd[cp]: |-
-        REDIS="'\OC\Memcache\Redis'"
         sed -i "36i     'filelocking.enabled' => true,"  /var/www/webroot/ROOT/config/config.php
         sed -i "37i     'memcache.locking' => '\\\OC\\\Memcache\\\Redis',"  /var/www/webroot/ROOT/config/config.php
         sed -i "38i     'memcache.local' => '\\\OC\\\Memcache\\\Redis',"  /var/www/webroot/ROOT/config/config.php

--- a/manifest.jps
+++ b/manifest.jps
@@ -1,7 +1,7 @@
 type: install
 id: owncloud
 name: ownCloud
-baseUrl: https://raw.githubusercontent.com/panslothda/owncloud/master
+baseUrl: https://raw.githubusercontent.com/jelastic-jps/owncloud/master
 homepage: https://owncloud.org/
 logo: images/ownCloud.png
 description: ownCloud represents an open source and free file cloud storage. It can be easily used for data sharing and synchronization, as well as just for storing documents.

--- a/manifest.jps
+++ b/manifest.jps
@@ -25,7 +25,7 @@ settings:
       type: checkbox
       caption: Install LiteSpeed High-Performance Web Server 
       value: true
-      tooltip: "If this option is disabled, the service will be installed using NGINX application server"
+      tooltip: "If this option is disabled, the service will be installed using Apache application server"
     - pack: ''
       align: ''
       defaultPadding: 1
@@ -39,7 +39,7 @@ settings:
       type: checkbox
       caption: Add a dedicated storage Node
       value: true
-      tooltip: "If this option is disabled, the storage of the NGINX node will be used for all files"
+      tooltip: "If this option is disabled, the storage of the Apache node will be used for all files"
       showIf:
         true:
           - caption: Clustered storage for high availability and more storage

--- a/manifest.jps
+++ b/manifest.jps
@@ -62,36 +62,48 @@ globals:
 
 
 onInstall:
-  - deploy:
+  - deployApp
+  - set-sql-settings
+  - set-php-settings
+
+actions:
+  deployApp:
+    deploy:  
       archive: https://download.owncloud.org/community/owncloud-${globals.version_owncloud}.zip
       name: owncloud-${globals.version_owncloud}.zip
       context: ROOT
-  - prepareSqlDatabase:
-    - nodeType: mariadb10
-      loginCredentials:
-        user: root
-        password: ${nodes.mariadb10.password}
-      newDatabaseName: owncloud
-      newDatabaseUser:
-        name: owncloud
-        password: ${globals.PASSWD}
-  - cmd [cp]: printf '<?php\n	$AUTOCONFIG = array(\n		"dbtype"	=> "mysql",\n		"dbname"	=> "owncloud",\n		"dbuser"	=> "owncloud",\n		"dbpass"	=> "${globals.PASSWD}",\n		"dbhost"	=> "${nodes.mariadb10.address}",\n		"dbtableprefix" => "oc_",\n		"adminlogin"	=> "admin",\n		"adminpass"	=> "${user.appPassword}",\n		"directory"	=> "/var/www/webroot/ROOT/data",\n);' > /var/www/webroot/ROOT/config/autoconfig.php
-  - replaceInFile:
-    - path: /etc/php.ini
+
+  set-sql-settings:
+    prepareSqlDatabase:
+      - nodeType: mariadb10
+        loginCredentials:
+          user: root
+          password: "${nodes.sqldb.password}"
+        newDatabaseName: owncloud
+        newDatabaseUser:
+          name: owncloud
+          password: "${user.appPassword}"
+    cmd [mariadb10]: mysql -u root -p${nodes.sqldb.password} -e "grant all privileges on *.* to 'owncloud'@'%'"
+
+  set-php-settings:        
+    cmd [cp]: printf '<?php\n	$AUTOCONFIG = array(\n		"dbtype"	=> "mysql",\n		"dbname"	=> "owncloud",\n		"dbuser"	=> "owncloud",\n		"dbpass"	=> "${user.appPassword}",\n		"dbhost"	=> "${nodes.sqldb.address}",\n		"dbtableprefix" => "oc_",\n		"adminlogin"	=> "admin",\n		"adminpass"	=> "${user.appPassword}",\n		"directory"	=> "/var/www/webroot/ROOT/data",\n);' > /var/www/webroot/ROOT/config/autoconfig.php
+   
+    replaceInFile:
       nodeGroup: cp
+      path: /etc/php.ini
       replacements:
-      - replacement: post_max_size = 256M
-        pattern: post_max_size = 8M
-      - replacement: upload_max_filesize = 256M
-        pattern: upload_max_filesize = 2M
-      - replacement: max_execution_time = 300
-        pattern: max_execution_time = 30
-      - pattern: ";extension=gd.so"
-        replacement: extension=gd.so
-      - pattern: ";extension=intl.so"
-        replacement: extension=intl.so
-      - pattern: cgi.fix_pathinfo=0
-        replacement: cgi.fix_pathinfo=1
+        - replacement: post_max_size = 256M
+          pattern: post_max_size = 8M
+        - replacement: upload_max_filesize = 256M
+          pattern: upload_max_filesize = 2M
+        - replacement: max_execution_time = 300
+          pattern: max_execution_time = 30
+        - pattern: ";extension=gd.so"
+          replacement: extension=gd.so
+        - pattern: ";extension=intl.so"
+          replacement: extension=intl.so
+        - pattern: cgi.fix_pathinfo=0
+          replacement: cgi.fix_pathinfo=1
 
 success:
   email: /text/success-text.md

--- a/scripts/beforeinstall.js
+++ b/scripts/beforeinstall.js
@@ -18,14 +18,7 @@ if (${settings.clustered-storage:false}) {
       env: {
         SERVER_WEBROOT: "/var/www/webroot/ROOT",
         REDIS_ENABLED: "true"
-      },
-      volumeMounts: {
-        "/var/www/webroot/ROOT": {
-          readOnly: "false",
-          sourcePath: "/data/ROOT",
-          sourceNodeGroup: "storage"
-          }
-        }  
+      } 
       }, {
       nodeType: "storage",
       count: 3,
@@ -50,14 +43,7 @@ if (${settings.clustered-storage:false}) {
       env: {
         SERVER_WEBROOT: "/var/www/webroot/ROOT",
         REDIS_ENABLED: "true"
-      },
-      volumeMounts: {
-        "/var/www/webroot/ROOT": {
-          readOnly: "false",
-          sourcePath: "/data/ROOT",
-          sourceNodeGroup: "storage"
-          }
-        }  
+      }  
       }, {
       nodeType: "storage",
       count: 3,

--- a/scripts/beforeinstall.js
+++ b/scripts/beforeinstall.js
@@ -1,3 +1,10 @@
+var resp = {
+  result: 0,
+  ssl: !!jelastic.billing.account.GetQuotas('environment.jelasticssl.enabled').array[0].value,
+  nodes: []
+}
+
+
 if ('${settings.clustered-storage}' == 'true') {
   resp.nodes.push({
     nodeType: "storage",

--- a/scripts/beforeinstall.js
+++ b/scripts/beforeinstall.js
@@ -1,6 +1,7 @@
 var resp = {
   result: 0,
   ssl: true,
+  engine: php7.4,
   nodes: []
 }
 

--- a/scripts/beforeinstall.js
+++ b/scripts/beforeinstall.js
@@ -5,37 +5,141 @@ var resp = {
   nodes: []
 }
 
-if (${settings.clustered-storage:false}) {   
-  resp.nodes.push({
-    nodeType: "storage",
-    count: 3,
-    cluster: true,
-    flexibleCloudlets: ${settings.st_flexibleCloudlets:8},
-    fixedCloudlets: ${settings.st_fixedCloudlets:1},
-    nodeGroup: "storage",
-    restartDelay: 10,
-    isRedeploySupport: false,
-    validation: {
-      minCount: 3,
-      maxCount: 3
-    }
-  })
+if (${settings.clustered-storage:false}) {
+  if (${settings.litespeed:false}) {
+    resp.nodes.push({
+      nodeType: "litespeedphp",
+      tag: "6.0-php-7.4.15",
+      engine: "7.4",
+      count: 1,
+      flexibleCloudlets: ${settings.cp_flexibleCloudlets:16},
+      fixedCloudlets: ${settings.cp_fixedCloudlets:1},
+      nodeGroup: "cp",
+      env: {
+        SERVER_WEBROOT: "/var/www/webroot/ROOT",
+        REDIS_ENABLED: "true"
+      },
+      volumeMounts: {
+        "/var/www/webroot/ROOT": {
+          readOnly: "false",
+          sourcePath: "/data/ROOT",
+          sourceNodeGroup: "storage"
+          }
+        }  
+      }, {
+      nodeType: "storage",
+      count: 3,
+      cluster: true,
+      flexibleCloudlets: ${settings.st_flexibleCloudlets:8},
+      fixedCloudlets: ${settings.st_fixedCloudlets:1},
+      nodeGroup: "storage",
+      restartDelay: 10,
+      isRedeploySupport: false,
+      validation: {
+        minCount: 3,
+        maxCount: 3
+      }
+    })
+    } else {
+    resp.nodes.push({    
+      nodeType: "nginxphp",
+      count: 1,
+      flexibleCloudlets: ${settings.cp_flexibleCloudlets:16},                  
+      fixedCloudlets: ${settings.cp_fixedCloudlets:1},
+      nodeGroup: "cp",
+      env: {
+        SERVER_WEBROOT: "/var/www/webroot/ROOT",
+        REDIS_ENABLED: "true"
+      },
+      volumeMounts: {
+        "/var/www/webroot/ROOT": {
+          readOnly: "false",
+          sourcePath: "/data/ROOT",
+          sourceNodeGroup: "storage"
+          }
+        }  
+      }, {
+      nodeType: "storage",
+      count: 3,
+      cluster: true,
+      flexibleCloudlets: ${settings.st_flexibleCloudlets:8},
+      fixedCloudlets: ${settings.st_fixedCloudlets:1},
+      nodeGroup: "storage",
+      restartDelay: 10,
+      isRedeploySupport: false,
+      validation: {
+        minCount: 3,
+        maxCount: 3
+      }
+    })
+  }
 } else {
-  if (${settings.ded-storage:false}) {
-  resp.nodes.push({
-    nodeType: "storage",
-    count: 1,
-    flexibleCloudlets: ${settings.st_flexibleCloudlets:8},
-    fixedCloudlets: ${settings.st_fixedCloudlets:1},
-    nodeGroup: "storage",
-    isRedeploySupport: false,
-    validation: {
-      minCount: 1,
-      maxCount: 1
-    }
-  })
-}
-}
+if (${settings.ded-storage:false}) {
+  if (${settings.litespeed:false}) {
+    resp.nodes.push({
+      nodeType: "litespeedphp",
+      tag: "6.0-php-7.4.15",
+      engine: "7.4",
+      count: 1,
+      flexibleCloudlets: ${settings.cp_flexibleCloudlets:16},
+      fixedCloudlets: ${settings.cp_fixedCloudlets:1},
+      nodeGroup: "cp",
+      env: {
+        SERVER_WEBROOT: "/var/www/webroot/ROOT",
+        REDIS_ENABLED: "true"
+      },
+      volumeMounts: {
+        "/var/www/webroot/ROOT": {
+          readOnly: "false",
+          sourcePath: "/data/ROOT",
+          sourceNodeGroup: "storage"
+          }
+        }  
+      }, {
+      nodeType: "storage",
+      count: 1,
+      flexibleCloudlets: ${settings.st_flexibleCloudlets:8},
+      fixedCloudlets: ${settings.st_fixedCloudlets:1},
+      nodeGroup: "storage",
+      isRedeploySupport: false,
+      validation: {
+        minCount: 1,
+        maxCount: 1
+      }
+    })
+  } else {
+    resp.nodes.push({    
+      nodeType: "nginxphp",
+      count: 1,
+      flexibleCloudlets: ${settings.cp_flexibleCloudlets:16},                  
+      fixedCloudlets: ${settings.cp_fixedCloudlets:1},
+      nodeGroup: "cp",
+      env: {
+        SERVER_WEBROOT: "/var/www/webroot/ROOT",
+        REDIS_ENABLED: "true"
+      },
+      volumeMounts: {
+        "/var/www/webroot/ROOT": {
+          readOnly: "false",
+          sourcePath: "/data/ROOT",
+          sourceNodeGroup: "storage"
+          }
+        }  
+      }, {
+      nodeType: "storage",
+      count: 1,
+      flexibleCloudlets: ${settings.st_flexibleCloudlets:8},
+      fixedCloudlets: ${settings.st_fixedCloudlets:1},
+      nodeGroup: "storage",
+      isRedeploySupport: false,
+      validation: {
+        minCount: 1,
+        maxCount: 1
+      }
+    })
+  }
+}}
+
 resp.nodes.push({
   nodeType: "mariadb-dockerized",
   flexibleCloudlets: ${settings.db_flexibleCloudlets:16},
@@ -49,21 +153,25 @@ resp.nodes.push({
     }
 })
 
-if (${settings.litespeed:false}) {
-  resp.nodes.push({
-    nodeType: "litespeedphp:latest",
-    count: 1,
-    flexibleCloudlets: ${settings.cp_flexibleCloudlets:16},
-    fixedCloudlets: ${settings.cp_fixedCloudlets:1},
-    nodeGroup: "cp",
-    env: {
-      SERVER_WEBROOT: "/var/www/webroot/ROOT",
-      REDIS_ENABLED: "true"
+
+if (!${settings.ded-storage:false}) {
+  if (${settings.litespeed:false}) {
+    resp.nodes.push({
+      nodeType: "litespeedphp",
+      tag: "6.0-php-7.4.15",
+      engine: "7.4",
+      count: 1,
+      flexibleCloudlets: ${settings.cp_flexibleCloudlets:16},
+      fixedCloudlets: ${settings.cp_fixedCloudlets:1},
+      nodeGroup: "cp",
+      env: {
+        SERVER_WEBROOT: "/var/www/webroot/ROOT",
+        REDIS_ENABLED: "true"
     }
   })
-} else {
+  } else {
   resp.nodes.push({
-    nodeType: "nginxphp:latest",
+    nodeType: "nginxphp",
     count: 1,
     flexibleCloudlets: ${settings.cp_flexibleCloudlets:16},                  
     fixedCloudlets: ${settings.cp_fixedCloudlets:1},
@@ -73,6 +181,6 @@ if (${settings.litespeed:false}) {
       REDIS_ENABLED: "true"
     }
   })
-}
+}}
 
 return resp;

--- a/scripts/beforeinstall.js
+++ b/scripts/beforeinstall.js
@@ -42,7 +42,7 @@ if (${settings.clustered-storage:false}) {
     })
     } else {
     resp.nodes.push({    
-      nodeType: "nginxphp",
+      nodeType: "apache2",
       count: 1,
       flexibleCloudlets: ${settings.cp_flexibleCloudlets:16},                  
       fixedCloudlets: ${settings.cp_fixedCloudlets:1},
@@ -109,7 +109,7 @@ if (${settings.ded-storage:false}) {
     })
   } else {
     resp.nodes.push({    
-      nodeType: "nginxphp",
+      nodeType: "apache2",
       count: 1,
       flexibleCloudlets: ${settings.cp_flexibleCloudlets:16},                  
       fixedCloudlets: ${settings.cp_fixedCloudlets:1},
@@ -171,7 +171,7 @@ if (!${settings.ded-storage:false}) {
   })
   } else {
   resp.nodes.push({
-    nodeType: "nginxphp",
+    nodeType: "apache2",
     count: 1,
     flexibleCloudlets: ${settings.cp_flexibleCloudlets:16},                  
     fixedCloudlets: ${settings.cp_fixedCloudlets:1},

--- a/scripts/beforeinstall.js
+++ b/scripts/beforeinstall.js
@@ -1,0 +1,63 @@
+if ('${settings.clustered-storage}' == 'true') {
+  resp.nodes.push({
+    nodeType: "storage",
+    count: 3,
+    cluster: true,
+    flexibleCloudlets: ${settings.st_flexibleCloudlets:8},
+    fixedCloudlets: ${settings.st_fixedCloudlets:1},
+    nodeGroup: "storage",
+    restartDelay: 10,
+    isRedeploySupport: false,
+    validation: {
+      minCount: 3,
+      maxCount: 3
+    }
+  })
+} else if ('${settings.ded-storage}' == 'true'){
+  resp.nodes.push({
+    nodeType: "storage",
+    count: 1,
+    flexibleCloudlets: ${settings.st_flexibleCloudlets:8},
+    fixedCloudlets: ${settings.st_fixedCloudlets:1},
+    nodeGroup: "storage",
+    isRedeploySupport: false,
+    validation: {
+      minCount: 1,
+      maxCount: 1
+    }
+  })
+}
+
+resp.nodes.push({
+  nodeType: "mariadb-dockerized",
+  flexibleCloudlets: ${settings.db_flexibleCloudlets:16},
+  fixedCloudlets: ${settings.db_fixedCloudlets:1},
+  count: 1,
+  nodeGroup: "sqldb",
+  skipNodeEmails: true,
+  validation: {
+    minCount: 1,
+    maxCount: 1
+  }
+  }  
+});
+
+if ('${settings.litespeed}'== 'true') {
+  resp.nodes.push({
+    nodeType: "litespeedphp",
+    count: 1,
+    flexibleCloudlets: ${settings.cp_flexibleCloudlets:16},
+    fixedCloudlets: ${settings.cp_fixedCloudlets:1},
+    nodeGroup: "cp"
+  })
+} else {
+  resp.nodes.push({
+    nodeType: "nginxphp",
+    count: 1,
+    flexibleCloudlets: ${settings.cp_flexibleCloudlets:16},                  
+    fixedCloudlets: ${settings.cp_fixedCloudlets:1},
+    nodeGroup: "cp"
+  })
+}
+
+return resp;

--- a/scripts/beforeinstall.js
+++ b/scripts/beforeinstall.js
@@ -1,7 +1,7 @@
 var resp = {
   result: 0,
   ssl: true,
-  engine: php7.4,
+  engine: "php7.4",
   nodes: []
 }
 
@@ -51,7 +51,7 @@ resp.nodes.push({
 
 if (${settings.litespeed:false}) {
   resp.nodes.push({
-    nodeType: "litespeedphp",
+    nodeType: "litespeedphp:latest",
     count: 1,
     flexibleCloudlets: ${settings.cp_flexibleCloudlets:16},
     fixedCloudlets: ${settings.cp_fixedCloudlets:1},
@@ -63,7 +63,7 @@ if (${settings.litespeed:false}) {
   })
 } else {
   resp.nodes.push({
-    nodeType: "nginxphp",
+    nodeType: "nginxphp:latest",
     count: 1,
     flexibleCloudlets: ${settings.cp_flexibleCloudlets:16},                  
     fixedCloudlets: ${settings.cp_fixedCloudlets:1},

--- a/scripts/beforeinstall.js
+++ b/scripts/beforeinstall.js
@@ -4,20 +4,7 @@ var resp = {
   nodes: []
 }
 
-if (${settings.ded-storage:false}) {
-  resp.nodes.push({
-    nodeType: "storage",
-    count: 1,
-    flexibleCloudlets: ${settings.st_flexibleCloudlets:8},
-    fixedCloudlets: ${settings.st_fixedCloudlets:1},
-    nodeGroup: "storage",
-    isRedeploySupport: false,
-    validation: {
-      minCount: 1,
-      maxCount: 1
-    }
-  })
-} else if (${settings.clustered-storage:false}) {
+if (${settings.clustered-storage:false}) {   
   resp.nodes.push({
     nodeType: "storage",
     count: 3,
@@ -32,8 +19,22 @@ if (${settings.ded-storage:false}) {
       maxCount: 3
     }
   })
+} else {
+  if (${settings.ded-storage:false}) {
+  resp.nodes.push({
+    nodeType: "storage",
+    count: 1,
+    flexibleCloudlets: ${settings.st_flexibleCloudlets:8},
+    fixedCloudlets: ${settings.st_fixedCloudlets:1},
+    nodeGroup: "storage",
+    isRedeploySupport: false,
+    validation: {
+      minCount: 1,
+      maxCount: 1
+    }
+  })
 }
-
+}
 resp.nodes.push({
   nodeType: "mariadb-dockerized",
   flexibleCloudlets: ${settings.db_flexibleCloudlets:16},

--- a/scripts/beforeinstall.js
+++ b/scripts/beforeinstall.js
@@ -1,11 +1,23 @@
 var resp = {
   result: 0,
-  ssl: !!jelastic.billing.account.GetQuotas('environment.jelasticssl.enabled').array[0].value,
+  ssl: true,
   nodes: []
 }
 
-
-if ('${settings.clustered-storage}' == 'true') {
+if (${settings.ded-storage:false}) {
+  resp.nodes.push({
+    nodeType: "storage",
+    count: 1,
+    flexibleCloudlets: ${settings.st_flexibleCloudlets:8},
+    fixedCloudlets: ${settings.st_fixedCloudlets:1},
+    nodeGroup: "storage",
+    isRedeploySupport: false,
+    validation: {
+      minCount: 1,
+      maxCount: 1
+    }
+  })
+} else if (${settings.clustered-storage:false}) {
   resp.nodes.push({
     nodeType: "storage",
     count: 3,
@@ -20,19 +32,6 @@ if ('${settings.clustered-storage}' == 'true') {
       maxCount: 3
     }
   })
-} else if ('${settings.ded-storage}' == 'true'){
-  resp.nodes.push({
-    nodeType: "storage",
-    count: 1,
-    flexibleCloudlets: ${settings.st_flexibleCloudlets:8},
-    fixedCloudlets: ${settings.st_fixedCloudlets:1},
-    nodeGroup: "storage",
-    isRedeploySupport: false,
-    validation: {
-      minCount: 1,
-      maxCount: 1
-    }
-  })
 }
 
 resp.nodes.push({
@@ -45,17 +44,20 @@ resp.nodes.push({
   validation: {
     minCount: 1,
     maxCount: 1
-  }
-  }  
-});
+    }
+})
 
-if ('${settings.litespeed}'== 'true') {
+if (${settings.litespeed:false}) {
   resp.nodes.push({
     nodeType: "litespeedphp",
     count: 1,
     flexibleCloudlets: ${settings.cp_flexibleCloudlets:16},
     fixedCloudlets: ${settings.cp_fixedCloudlets:1},
-    nodeGroup: "cp"
+    nodeGroup: "cp",
+    env: {
+      SERVER_WEBROOT: "/var/www/webroot/ROOT",
+      REDIS_ENABLED: "true"
+    }
   })
 } else {
   resp.nodes.push({
@@ -63,7 +65,11 @@ if ('${settings.litespeed}'== 'true') {
     count: 1,
     flexibleCloudlets: ${settings.cp_flexibleCloudlets:16},                  
     fixedCloudlets: ${settings.cp_fixedCloudlets:1},
-    nodeGroup: "cp"
+    nodeGroup: "cp",
+    env: {
+      SERVER_WEBROOT: "/var/www/webroot/ROOT",
+      REDIS_ENABLED: "true"
+    }
   })
 }
 

--- a/text/success-email.md
+++ b/text/success-email.md
@@ -1,0 +1,8 @@
+  Below you will find your admin panel link, username and password.  
+  
+  
+  Admin panel URL: [${env.protocol}://${env.domain}/](${env.protocol}://${env.domain}/)  
+  Admin name: admin  
+  Password: ${user.appPassword}  
+  
+  To add custom domain name for your ownCloud installation follow the steps described in our [documentation](http://docs.jelastic.com/custom-domains)

--- a/text/success-email.md
+++ b/text/success-email.md
@@ -6,3 +6,5 @@
   Password: ${user.appPassword}  
   
   To add custom domain name for your ownCloud installation follow the steps described in our [documentation](http://docs.jelastic.com/custom-domains)
+
+  You can find a guide for ownCloud Administration here: https://doc.owncloud.com/server/user_manual/files/webgui/overview.html

--- a/text/success-text.md
+++ b/text/success-text.md
@@ -1,8 +1,6 @@
   Below you will find your admin panel link, username and password.  
   
-  
   Admin panel URL: [${env.protocol}://${env.domain}/](${env.protocol}://${env.domain}/)  
   Admin name: admin  
   Password: ${user.appPassword}  
   
-  To add custom domain name for your ownCloud installation follow the steps described in our [documentation](http://docs.jelastic.com/custom-domains)

--- a/text/success-text.md
+++ b/text/success-text.md
@@ -1,0 +1,8 @@
+  Below you will find your admin panel link, username and password.  
+  
+  
+  Admin panel URL: [${env.protocol}://${env.domain}/](${env.protocol}://${env.domain}/)  
+  Admin name: admin  
+  Password: ${user.appPassword}  
+  
+  To add custom domain name for your ownCloud installation follow the steps described in our [documentation](http://docs.jelastic.com/custom-domains)


### PR DESCRIPTION
Hi,

Here is the complete rework of this JPS:

Changes:

Added a beforeinstall.js file that defines the nodes depending on users selection.
Added option of using litespeed or apache and dedicated storage or storage cluster 
activated built-in SSL by default
enabled system cron by default for owncloud
enabled and added redis configuration to owncloud
Split out text for success message into dedicated files
Separate messages for e-mail and direct text with individual infos
set appropriate cloudlets for idle load

I tested it on the infomaniak platform but not on other ones and for me it worked well :)

Let me know if you have any comments or questions